### PR TITLE
Added `StaticDataSize` trait and derive macros for `DataSize` and `StaticDataSize`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target
-/Cargo.lock
+*/target
+*/Cargo.lock
 /.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ categories = [ "encoding" ]
 [dependencies]
 #thiserror = "1.0"
 bytes = "1.2"
+datasize_macro = { path = "./datasize_macro" }

--- a/datasize_macro/Cargo.toml
+++ b/datasize_macro/Cargo.toml
@@ -1,7 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 [package]
 name = "datasize_macro"
+description = "Derive macro for implementing DataSize and StaticDataSize traits"
 version = "0.1.0"
 edition = "2021"
+readme = false
+authors = [ "X.RS", "Antikyth <antikyth at gmail dot com>", "Syudagye <syudagye@gmail.com>" ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/datasize_macro/Cargo.toml
+++ b/datasize_macro/Cargo.toml
@@ -11,3 +11,4 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0.103", features = ["full"] }
 quote = "1.0.21"
+proc-macro2 = "1.0.47"

--- a/datasize_macro/Cargo.toml
+++ b/datasize_macro/Cargo.toml
@@ -8,7 +8,7 @@ description = "Derive macro for implementing DataSize and StaticDataSize traits"
 version = "0.1.0"
 edition = "2021"
 readme = false
-authors = [ "X.RS", "Antikyth <antikyth at gmail dot com>", "Syudagye <syudagye@gmail.com>" ]
+authors = [ "X.RS", "Syudagye <syudagye@gmail.com>" ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/datasize_macro/Cargo.toml
+++ b/datasize_macro/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "datasize_macro"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0.103", features = ["full"] }
+quote = "1.0.21"

--- a/datasize_macro/src/impl_data_sizes.rs
+++ b/datasize_macro/src/impl_data_sizes.rs
@@ -128,25 +128,6 @@ fn impl_static_datasize_struct(data_struct: &DataStruct) -> TokenStream2 {
 /// This replaces all types to a syntax on which we can call functions
 fn replace_type_syntax(t: Type) -> TokenStream2 {
 	match t {
-		// If it is a path type, we need to replace its arguments is there is some
-		// Basically tansforming every Type<T> into Type::<T>
-		Type::Path(p) => {
-			let idents: Vec<_> = p
-				.path
-				.segments
-				.iter()
-				.map(|s| {
-					let ident = &s.ident;
-					// Only retain angle btracketed arguments
-					let PathArguments::AngleBracketed(arg) = &s.arguments else {
-								return quote!(#ident);
-							};
-					// TODO: Support recursive arguments (Things like Option<Thing<T>>)
-					quote!(#ident::#arg)
-				})
-				.collect();
-			quote!(#(#idents)*)
-		}
 		Type::Tuple(t) => {
 			let types: Vec<TokenStream2> = t
 				.elems
@@ -172,6 +153,7 @@ fn replace_type_syntax(t: Type) -> TokenStream2 {
 			quote!(#ty)
 		}
 		Type::Infer(i) => i.to_token_stream(),
+        Type::Path(p) => p.to_token_stream(),
 		_ => panic!("This type is not supported yet"),
 	}
 }

--- a/datasize_macro/src/impl_data_sizes.rs
+++ b/datasize_macro/src/impl_data_sizes.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Ident, Index, PathArguments, Type};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Ident, Index, Type};
 
 pub fn impl_datasize(input: &DeriveInput) -> TokenStream2 {
 	match &input.data {
@@ -153,7 +153,7 @@ fn replace_type_syntax(t: Type) -> TokenStream2 {
 			quote!(#ty)
 		}
 		Type::Infer(i) => i.to_token_stream(),
-        Type::Path(p) => p.to_token_stream(),
+		Type::Path(p) => p.to_token_stream(),
 		_ => panic!("This type is not supported yet"),
 	}
 }

--- a/datasize_macro/src/impl_data_sizes.rs
+++ b/datasize_macro/src/impl_data_sizes.rs
@@ -1,0 +1,149 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{
+	Data, DataEnum, DataStruct, DeriveInput, Fields, Ident, Index, PathArguments, Type,
+};
+
+pub fn impl_datasize(input: &DeriveInput) -> TokenStream2 {
+	match &input.data {
+		Data::Enum(e) => impl_datasize_enum(e),
+		Data::Struct(s) => impl_datasize_struct(s),
+		Data::Union(_) => {
+			panic!("Unions are used for C bindings, you probably don't need this trait for it");
+		}
+	}
+}
+
+pub fn impl_static_data_size(input: &DeriveInput) -> TokenStream2 {
+	match &input.data {
+		Data::Enum(e) => impl_static_datasize_enum(e),
+		Data::Struct(s) => impl_static_datasize_struct(s),
+		syn::Data::Union(_) => {
+			panic!("Unions are used for C bindings, you probably don't need this trait for it");
+		}
+	}
+}
+
+fn impl_datasize_enum(data_enum: &DataEnum) -> TokenStream2 {
+	let branches = data_enum
+		.variants
+		.iter()
+		.map(|v| {
+			let ident = &v.ident;
+			match &v.fields {
+				Fields::Named(f) => {
+					// Get a list of all named fields of a named variant
+					let names: Vec<Ident> =
+						f.named.iter().filter_map(|f| f.ident.to_owned()).collect();
+
+					quote! {
+						Self::#ident {#(#names),*} => { usize::default() #( + #names.data_size())*},
+					}
+				}
+				Fields::Unnamed(f) => {
+					// Set a name for all fields of an unnamed variant
+					let names: Vec<Ident> = f
+						.unnamed
+						.iter()
+						.enumerate()
+						.map(|(i, _)| format_ident!("f{}", i))
+						.collect();
+
+					quote! {
+						Self::#ident (#(#names),*) => { usize::default() #( + #names.data_size())*},
+					}
+				}
+				// If the variant is a unit variant, then the size is 0
+				Fields::Unit => quote! {
+					Self::#ident => 0,
+				},
+			}
+		})
+		.fold(quote!(), |t, b| quote! (#t #b));
+
+	quote! {
+		match &self {
+			#branches
+		}
+	}
+}
+
+fn impl_datasize_struct(data_struct: &DataStruct) -> TokenStream2 {
+	match &data_struct.fields {
+		Fields::Named(f) => {
+			// Get a list of all named fields of a named variant
+			let names: Vec<Ident> = f.named.iter().filter_map(|f| f.ident.to_owned()).collect();
+
+			quote! {
+				usize::default() #(+ self.#names.data_size())*
+			}
+		}
+		Fields::Unnamed(f) => {
+			// Set a name for all fields of an unnamed variant
+			let names: Vec<Index> = f
+				.unnamed
+				.iter()
+				.enumerate()
+				.map(|(i, _)| Index::from(i))
+				.collect();
+
+			quote! {
+				usize::default() #(+ self.#names.data_size())*
+			}
+		}
+		// If the variant is a unit variant, then the size is 0
+		Fields::Unit => quote!(usize::default()),
+	}
+}
+
+fn impl_static_datasize_enum(data_enum: &DataEnum) -> TokenStream2 {
+	data_enum
+		.variants
+		.iter()
+		.map(|v| {
+			// Retrieve types for all fields
+			let types: Vec<Type> = v.fields.iter().map(|f| f.ty.to_owned()).collect();
+			quote! {
+				usize::default() #( + #types::static_data_size())*
+			}
+		})
+		// Use the maximum size among all variants
+		.fold(
+			quote!(usize::default()),
+			|t, b| quote!(std::cmp::max(#t, #b)),
+		)
+}
+
+fn impl_static_datasize_struct(data_struct: &DataStruct) -> TokenStream2 {
+	// Retrieve types of all fields
+	let types: Vec<_> = data_struct
+		.fields
+		.iter()
+		.map(|f| f.ty.to_owned())
+		.filter_map(|t| match t {
+			Type::Path(p) => Some(p),
+			_ => None,
+		})
+		// Replacing every paths segments angle brackets argument
+		// Basically tansforming every Type<T> into Type::<T>
+		.map(|p| {
+			let idents: Vec<_> = p
+				.path
+				.segments
+				.iter()
+				.map(|s| {
+					let ident = &s.ident;
+					// Only retain angle btracketed arguments
+					let PathArguments::AngleBracketed(arg) = &s.arguments else {
+								return quote!(#ident);
+							};
+					quote!(#ident::#arg)
+				})
+				.collect();
+			quote!(#(#idents)*)
+		})
+		.collect();
+
+	// We call `static_data_size()` on each of the names
+	quote! ( usize::default() #(+ #types::static_data_size())*)
+}

--- a/datasize_macro/src/impl_data_sizes.rs
+++ b/datasize_macro/src/impl_data_sizes.rs
@@ -55,9 +55,9 @@ fn impl_datasize_enum(data_enum: &DataEnum) -> TokenStream2 {
 						Self::#ident (#(#names),*) => { 0usize #( + #names.data_size())*},
 					}
 				}
-				// If the variant is a unit variant, then the size is 0
+				// If the variant is a unit variant, then the size is 1 (size of it's discriminant)
 				Fields::Unit => quote! {
-					Self::#ident => 0,
+					Self::#ident => 1,
 				},
 			}
 		})

--- a/datasize_macro/src/impl_data_sizes.rs
+++ b/datasize_macro/src/impl_data_sizes.rs
@@ -165,25 +165,3 @@ fn replace_type_syntax(r#type: Type) -> TokenStream2 {
 		_ => panic!("This type is not supported yet"),
 	}
 }
-
-/// Get all renerics idents
-pub fn retrieve_type_generics(input: &DeriveInput) -> Vec<Ident> {
-	input
-		.generics
-		.type_params()
-		.map(|r#type| r#type.ident.to_owned())
-		.collect()
-}
-/// Get all generics, but replaces lifetimes with anonymous lifetimes
-pub fn retrieve_generics_with_anonymous_lifetimes(input: &DeriveInput) -> Vec<TokenStream2> {
-	input
-		.generics
-		.params
-		.iter()
-		.filter_map(|generics| match generics {
-			syn::GenericParam::Type(t) => Some(t.to_token_stream()),
-			syn::GenericParam::Lifetime(_) => Some(quote!('_)),
-			syn::GenericParam::Const(_) => None,
-		})
-		.collect()
-}

--- a/datasize_macro/src/impl_data_sizes.rs
+++ b/datasize_macro/src/impl_data_sizes.rs
@@ -76,7 +76,7 @@ fn impl_datasize_enum(data_enum: &DataEnum) -> TokenStream2 {
 fn impl_datasize_struct(data_struct: &DataStruct) -> TokenStream2 {
 	match &data_struct.fields {
 		Fields::Named(field) => {
-			// Get a list of all named fields of a named variant
+			// Get a list of all named fields
 			let names: Vec<&Ident> = field
 				.named
 				.iter()

--- a/datasize_macro/src/impl_data_sizes.rs
+++ b/datasize_macro/src/impl_data_sizes.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Ident, Index, Type};

--- a/datasize_macro/src/impl_data_sizes.rs
+++ b/datasize_macro/src/impl_data_sizes.rs
@@ -1,8 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use syn::{
-	Data, DataEnum, DataStruct, DeriveInput, Fields, Ident, Index, PathArguments, Type,
-};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Ident, Index, PathArguments, Type};
 
 pub fn impl_datasize(input: &DeriveInput) -> TokenStream2 {
 	match &input.data {
@@ -146,4 +144,12 @@ fn impl_static_datasize_struct(data_struct: &DataStruct) -> TokenStream2 {
 
 	// We call `static_data_size()` on each of the names
 	quote! ( usize::default() #(+ #types::static_data_size())*)
+}
+
+pub fn retrieve_generics(input: &DeriveInput) -> Vec<Ident> {
+	input
+		.generics
+		.type_params()
+		.map(|t| t.ident.to_owned())
+		.collect()
 }

--- a/datasize_macro/src/impl_data_sizes.rs
+++ b/datasize_macro/src/impl_data_sizes.rs
@@ -166,14 +166,24 @@ fn replace_type_syntax(r#type: Type) -> TokenStream2 {
 	}
 }
 
-pub fn retrieve_generics(input: &DeriveInput) -> Vec<Ident> {
+/// Get all renerics idents
+pub fn retrieve_type_generics(input: &DeriveInput) -> Vec<Ident> {
 	input
 		.generics
 		.type_params()
 		.map(|r#type| r#type.ident.to_owned())
 		.collect()
 }
-
-pub fn retrieve_lifetimes(input: &DeriveInput) -> Vec<TokenStream2> {
-	input.generics.lifetimes().map(|_| quote!('_)).collect()
+/// Get all generics, but replaces lifetimes with anonymous lifetimes
+pub fn retrieve_generics_with_anonymous_lifetimes(input: &DeriveInput) -> Vec<TokenStream2> {
+	input
+		.generics
+		.params
+		.iter()
+		.filter_map(|generics| match generics {
+			syn::GenericParam::Type(t) => Some(t.to_token_stream()),
+			syn::GenericParam::Lifetime(_) => Some(quote!('_)),
+			syn::GenericParam::Const(_) => None,
+		})
+		.collect()
 }

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -1,85 +1,15 @@
+use impl_data_sizes::{impl_datasize, impl_static_data_size};
 use proc_macro::TokenStream;
-use quote::{format_ident, quote};
-use syn::{parse_macro_input, Data, DeriveInput, Fields, Ident, Index, PathArguments, Type};
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+mod impl_data_sizes;
 
 #[proc_macro_derive(DataSize)]
 pub fn derive_data_size(item: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(item as DeriveInput);
-	let ident = input.ident;
-
-	let inner = match input.data {
-		Data::Enum(e) => {
-			let branches = e
-				.variants
-				.iter()
-				.map(|v| {
-					let ident = &v.ident;
-					match &v.fields {
-						Fields::Named(f) => {
-							// Get a list of all named fields of a named variant
-							let names: Vec<Ident> =
-								f.named.iter().filter_map(|f| f.ident.to_owned()).collect();
-
-							quote! {
-								Self::#ident {#(#names),*} => { usize::default() #( + #names.data_size())*},
-							}
-						}
-						Fields::Unnamed(f) => {
-							// Set a name for all fields of an unnamed variant
-							let names: Vec<Ident> = f
-								.unnamed
-								.iter()
-								.enumerate()
-								.map(|(i, _)| format_ident!("f{}", i))
-								.collect();
-
-							quote! {
-								Self::#ident (#(#names),*) => { usize::default() #( + #names.data_size())*},
-							}
-						}
-						// If the variant is a unit variant, then the size is 0
-						Fields::Unit => quote! {
-							Self::#ident => 0,
-						},
-					}
-				})
-				.fold(quote!(), |t, b| quote! (#t #b));
-
-			quote! {
-				match &self {
-					#branches
-				}
-			}
-		}
-		Data::Struct(s) => match &s.fields {
-			Fields::Named(f) => {
-				// Get a list of all named fields of a named variant
-				let names: Vec<Ident> = f.named.iter().filter_map(|f| f.ident.to_owned()).collect();
-
-				quote! {
-					usize::default() #(+ self.#names.data_size())*
-				}
-			}
-			Fields::Unnamed(f) => {
-				// Set a name for all fields of an unnamed variant
-				let names: Vec<Index> = f
-					.unnamed
-					.iter()
-					.enumerate()
-					.map(|(i, _)| Index::from(i))
-					.collect();
-
-				quote! {
-					usize::default() #(+ self.#names.data_size())*
-				}
-			}
-			// If the variant is a unit variant, then the size is 0
-			Fields::Unit => quote!(usize::default()),
-		},
-		Data::Union(_) => {
-			panic!("Unions are used for C bindings, you probably don't need this trait for it");
-		}
-	};
+	let ident = &input.ident;
+	let inner = impl_datasize(&input);
 
 	let output = quote! {
 		impl cornflakes::datasize::DataSize for #ident {
@@ -94,62 +24,8 @@ pub fn derive_data_size(item: TokenStream) -> TokenStream {
 #[proc_macro_derive(StaticDataSize)]
 pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(item as DeriveInput);
-	let ident = input.ident;
-
-	let inner = match input.data {
-		Data::Enum(e) => {
-			e.variants
-				.iter()
-				.map(|v| {
-					// Retrieve types for all fields
-					let types: Vec<Type> = v.fields.iter().map(|f| f.ty.to_owned()).collect();
-					quote! {
-						usize::default() #( + #types::static_data_size())*
-					}
-				})
-				// Use the maximum size among all variants
-				.fold(
-					quote!(usize::default()),
-					|t, b| quote!(std::cmp::max(#t, #b)),
-				)
-		}
-		Data::Struct(s) => {
-			// Retrieve types of all fields
-			let types: Vec<_> = s
-				.fields
-				.iter()
-				.map(|f| f.ty.to_owned())
-				.filter_map(|t| match t {
-					Type::Path(p) => Some(p),
-					_ => None,
-				})
-				// Replacing every paths segments angle brackets argument
-				// Basically tansforming every Type<T> into Type::<T>
-				.map(|p| {
-					let idents: Vec<_> = p
-						.path
-						.segments
-						.iter()
-						.map(|s| {
-							let ident = &s.ident;
-							// Only retain angle btracketed arguments
-							let PathArguments::AngleBracketed(arg) = &s.arguments else {
-								return quote!(#ident);
-							};
-							quote!(#ident::#arg)
-						})
-						.collect();
-					quote!(#(#idents)*)
-				})
-				.collect();
-
-			// We call `static_data_size()` on each of the names
-			quote! ( usize::default() #(+ #types::static_data_size())*)
-		}
-		syn::Data::Union(_) => {
-			panic!("Unions are used for C bindings, you probably don't need this trait for it");
-		}
-	};
+	let ident = &input.ident;
+	let inner = impl_static_data_size(&input);
 
 	// TODO: Move the implementation for `DataSize` to the appropriate derive macro
 	// TODO: Implement Generics support

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use impl_data_sizes::{
 	impl_datasize, impl_static_data_size, retrieve_generics, retrieve_lifetimes,
 };

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -31,7 +31,6 @@ pub fn derive_data_size(item: TokenStream) -> TokenStream {
 			}
 		}
 	};
-	dbg!(&output.to_string());
 	output.into()
 }
 
@@ -65,6 +64,5 @@ pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
 			}
 		}
 	};
-	dbg!(&output.to_string());
 	output.into()
 }

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -1,15 +1,94 @@
 use proc_macro::TokenStream;
-use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, DeriveInput, Ident, Type};
+
+// mod definitions;
 
 #[proc_macro_derive(DataSize)]
 pub fn derive_data_size(item: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(item as DeriveInput);
 	let ident = input.ident;
+
+	let inner = match input.data {
+		syn::Data::Enum(e) => {
+			let branches = e
+				.variants
+				.iter()
+				.map(|v| {
+					let ident = &v.ident;
+					let fields_named = v.fields.iter().all(|v| v.ident.is_some());
+					if fields_named {
+						// Get a list of all named fields of the variant
+						let names: Vec<Ident> = v
+							.fields
+							.iter()
+							.filter_map(|f| {
+								if let Some(name) = &f.ident {
+									Some(format_ident!("{}", name.to_string()))
+								} else {
+									None
+								}
+							})
+							.collect();
+
+						quote! {
+							Self::#ident {#(#names),*} => { usize::default() #( + #names.data_size())*},
+						}
+					} else if v.fields.len() > 0 {
+						// Set a name for all fields of a variant
+						let names: Vec<Ident> = v
+							.fields
+							.iter()
+							.enumerate()
+							.map(|(i, _)| format_ident!("f{}", i))
+							.collect();
+
+						quote! {
+							Self::#ident (#(#names),*) => { usize::default() #( + #names.data_size())*},
+						}
+					} else {
+						// If the variant is a unit variant, then the size is 0
+						quote! {
+							Self::#ident => 0,
+						}
+					}
+				})
+				.fold(quote!(), |t, b| quote! (#t #b));
+
+			quote! {
+				match &self {
+					#branches
+				}
+			}
+		}
+		syn::Data::Struct(s) => {
+			// Retreive the names of all the fields
+			let names: Vec<Ident> = s
+				.fields
+				.iter()
+				.enumerate()
+				.map(|(i, f)| {
+					if let Some(ident) = &f.ident {
+						format_ident!("{}", ident.to_string())
+					} else {
+						format_ident!("{}", i)
+					}
+				})
+				.collect();
+
+			// We call `data_size()` on each of the names
+			quote! { usize::default() #(+ self.#names.data_size())*}
+		}
+		syn::Data::Union(_) => {
+			// TODO: find you what to do here
+			quote! {0}
+		}
+	};
+
 	let output = quote! {
 		impl cornflakes::datasize::DataSize for #ident {
 			fn data_size(&self) -> usize {
-				usize::default()
+				#inner
 			}
 		}
 	};
@@ -20,16 +99,52 @@ pub fn derive_data_size(item: TokenStream) -> TokenStream {
 pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(item as DeriveInput);
 	let ident = input.ident;
+
+	let inner = match input.data {
+		syn::Data::Enum(e) => {
+			e.variants
+				.iter()
+				.map(|v| {
+					// Retrieve types for all fields
+					let types: Vec<Type> = v.fields.iter().map(|f| f.ty.to_owned()).collect();
+					quote! {
+						usize::default() #( + #types::static_data_size())*
+					}
+				})
+				// Use the maximum size among all variants
+				.fold(
+					quote!(usize::default()),
+					|t, b| quote! (std::cmp::max(#t, #b)),
+				)
+		}
+		syn::Data::Struct(s) => {
+			// Retrieve types of all fields
+			let types: Vec<Type> = s.fields.iter().map(|f| f.ty.to_owned()).collect();
+
+			// We call `static_data_size()` on each of the names
+			// TODO: Find a way to implement wrapper types like Option<T>
+			//       We need to call the function like this:
+			//          Option::<T>::static_data_size()
+			// quote! { usize::default() #(+ #types::static_data_size())*}
+			quote! {0}
+		}
+		syn::Data::Union(_) => {
+			// TODO: find you what to do here
+			quote! {0}
+		}
+	};
+
+	// TODO: Move the implementation for `DataSize` to the appropriate derive macro
 	let output = quote! {
 		impl cornflakes::datasize::StaticDataSize for #ident {
 			fn static_data_size() -> usize {
-				usize::default()
+				#inner
 			}
 		}
 		impl cornflakes::datasize::DataSize for #ident {
-		    fn data_size(&self) -> usize {
-		        Self::static_data_size()
-		    }
+			fn data_size(&self) -> usize {
+				Self::static_data_size()
+			}
 		}
 	};
 	TokenStream::from(output)

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -17,8 +17,8 @@ pub fn derive_data_size(item: TokenStream) -> TokenStream {
 	let ident = &input.ident;
 	let inner = impl_datasize(&input);
 
-	input.generics.type_params_mut().for_each(|t| {
-		t.bounds.push(parse_quote!(cornflakes::DataSize));
+	input.generics.type_params_mut().for_each(|param| {
+		param.bounds.push(parse_quote!(cornflakes::DataSize));
 	});
 	let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
 
@@ -38,8 +38,8 @@ pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
 	let ident = &input.ident;
 	let inner = impl_static_data_size(&input);
 
-	input.generics.type_params_mut().for_each(|t| {
-		t.bounds.push(parse_quote!(cornflakes::StaticDataSize));
+	input.generics.type_params_mut().for_each(|param| {
+		param.bounds.push(parse_quote!(cornflakes::StaticDataSize));
 	});
 	let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
 
@@ -53,8 +53,8 @@ pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
 
 	// For specialization to work, we need an additionnal trait bound for Datasize
 	// that we couldn't add before
-	input.generics.type_params_mut().for_each(|t| {
-		t.bounds.push(parse_quote!(cornflakes::DataSize));
+	input.generics.type_params_mut().for_each(|param| {
+		param.bounds.push(parse_quote!(cornflakes::DataSize));
 	});
 	let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
 

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -135,14 +135,14 @@ pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
 						.segments
 						.iter()
 						.map(|s| {
+							let ident = &s.ident;
 							let PathArguments::AngleBracketed(arg) = &s.arguments else {
-								return quote!(format_ident!("{}", s.ident));
+								return quote!(#ident);
 							};
-							let arg = arg.to_token_stream();
-							quote!(format_ident!("{}", s.ident)::#arg)
+							quote!(#ident::#arg)
 						})
 						.collect();
-					quote!(#(::#idents)*)
+					quote!(#(#idents)*)
 				})
 				.collect();
 

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -1,0 +1,36 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(DataSize)]
+pub fn derive_data_size(item: TokenStream) -> TokenStream {
+	let input = parse_macro_input!(item as DeriveInput);
+	let ident = input.ident;
+	let output = quote! {
+		impl cornflakes::datasize::DataSize for #ident {
+			fn data_size(&self) -> usize {
+				usize::default()
+			}
+		}
+	};
+	TokenStream::from(output)
+}
+
+#[proc_macro_derive(StaticDataSize)]
+pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
+	let input = parse_macro_input!(item as DeriveInput);
+	let ident = input.ident;
+	let output = quote! {
+		impl cornflakes::datasize::StaticDataSize for #ident {
+			fn static_data_size() -> usize {
+				usize::default()
+			}
+		}
+		impl cornflakes::datasize::DataSize for #ident {
+		    fn data_size(&self) -> usize {
+		        Self::static_data_size()
+		    }
+		}
+	};
+	TokenStream::from(output)
+}

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -1,4 +1,4 @@
-use impl_data_sizes::{impl_datasize, impl_static_data_size};
+use impl_data_sizes::{impl_datasize, impl_static_data_size, retrieve_generics};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
@@ -10,10 +10,11 @@ pub fn derive_data_size(item: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(item as DeriveInput);
 	let ident = &input.ident;
 	let inner = impl_datasize(&input);
+	let generics = retrieve_generics(&input);
 
 	let output = quote! {
-		impl cornflakes::datasize::DataSize for #ident {
-			fn data_size(&self) -> usize {
+		impl<#(#generics: DataSize),*> cornflakes::datasize::DataSize for #ident<#(#generics)*> {
+			default fn data_size(&self) -> usize {
 				#inner
 			}
 		}
@@ -26,16 +27,16 @@ pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(item as DeriveInput);
 	let ident = &input.ident;
 	let inner = impl_static_data_size(&input);
+	let generics = retrieve_generics(&input);
 
 	// TODO: Move the implementation for `DataSize` to the appropriate derive macro
-	// TODO: Implement Generics support
 	let output = quote! {
-		impl cornflakes::datasize::StaticDataSize for #ident {
+		impl<#(#generics: StaticDataSize),*> cornflakes::datasize::StaticDataSize for #ident<#(#generics)*> {
 			fn static_data_size() -> usize {
 				#inner
 			}
 		}
-		impl cornflakes::datasize::DataSize for #ident {
+		impl<#(#generics: StaticDataSize + DataSize),*> cornflakes::datasize::DataSize for #ident<#(#generics)*> {
 			fn data_size(&self) -> usize {
 				Self::static_data_size()
 			}

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -29,7 +29,7 @@ pub fn derive_data_size(item: TokenStream) -> TokenStream {
 	};
 
 	let output = quote! {
-		impl<#(#generics: DataSize),*> cornflakes::datasize::DataSize for #ident #generics_and_lifetimes {
+		impl<#(#generics: cornflakes::DataSize),*> cornflakes::DataSize for #ident #generics_and_lifetimes {
 			default fn data_size(&self) -> usize {
 				#inner
 			}
@@ -57,12 +57,12 @@ pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
 
 	// TODO: Move the implementation for `DataSize` to the appropriate derive macro
 	let output = quote! {
-		impl<#(#generics: StaticDataSize),*> cornflakes::datasize::StaticDataSize for #ident #generics_and_lifetimes {
+		impl<#(#generics: cornflakes::StaticDataSize),*> cornflakes::StaticDataSize for #ident #generics_and_lifetimes {
 			fn static_data_size() -> usize {
 				#inner
 			}
 		}
-		impl<#(#generics: StaticDataSize + DataSize),*> cornflakes::datasize::DataSize for #ident #generics_and_lifetimes {
+		impl<#(#generics: cornflakes::StaticDataSize + cornflakes::DataSize),*> cornflakes::DataSize for #ident #generics_and_lifetimes {
 			fn data_size(&self) -> usize {
 				Self::static_data_size()
 			}

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -2,26 +2,28 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use impl_data_sizes::{
-	impl_datasize, impl_static_data_size, retrieve_generics_with_anonymous_lifetimes, retrieve_type_generics,
-};
+use impl_data_sizes::{impl_datasize, impl_static_data_size};
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{
+	parse_macro_input, parse_quote, DeriveInput,
+};
 
 mod impl_data_sizes;
 
 #[proc_macro_derive(DataSize)]
 pub fn derive_data_size(item: TokenStream) -> TokenStream {
-	let input = parse_macro_input!(item as DeriveInput);
+	let mut input = parse_macro_input!(item as DeriveInput);
 	let ident = &input.ident;
 	let inner = impl_datasize(&input);
 
-	let generics = retrieve_type_generics(&input);
-	let generics_and_anonymous_lifetimes = retrieve_generics_with_anonymous_lifetimes(&input);
+	input.generics.type_params_mut().for_each(|t| {
+		t.bounds.push(parse_quote!(cornflakes::DataSize));
+	});
+	let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
 
 	let output = quote! {
-		impl<#(#generics: cornflakes::DataSize),*> cornflakes::DataSize for #ident <#(#generics_and_anonymous_lifetimes),*> {
+		impl #impl_generics cornflakes::DataSize for #ident #type_generics #where_clause {
 			default fn data_size(&self) -> usize {
 				#inner
 			}
@@ -32,21 +34,33 @@ pub fn derive_data_size(item: TokenStream) -> TokenStream {
 
 #[proc_macro_derive(StaticDataSize)]
 pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
-	let input = parse_macro_input!(item as DeriveInput);
+	let mut input = parse_macro_input!(item as DeriveInput);
 	let ident = &input.ident;
 	let inner = impl_static_data_size(&input);
 
-	let generics = retrieve_type_generics(&input);
-	let generics_and_anonymous_lifetimes = retrieve_generics_with_anonymous_lifetimes(&input);
+	input.generics.type_params_mut().for_each(|t| {
+		t.bounds.push(parse_quote!(cornflakes::StaticDataSize));
+	});
+	let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
 
-	// TODO: Move the implementation for `DataSize` to the appropriate derive macro
 	let output = quote! {
-		impl<#(#generics: cornflakes::StaticDataSize),*> cornflakes::StaticDataSize for #ident <#(#generics_and_anonymous_lifetimes),*> {
+		impl #impl_generics cornflakes::StaticDataSize for #ident #type_generics #where_clause {
 			fn static_data_size() -> usize {
 				#inner
 			}
 		}
-		impl<#(#generics: cornflakes::StaticDataSize + cornflakes::DataSize),*> cornflakes::DataSize for #ident <#(#generics_and_anonymous_lifetimes),*> {
+	};
+
+	// For specialization to work, we need an additionnal trait bound for Datasize
+	// that we couldn't add before
+	input.generics.type_params_mut().for_each(|t| {
+		t.bounds.push(parse_quote!(cornflakes::DataSize));
+	});
+	let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+
+	let output = quote! {
+		#output
+		impl #impl_generics cornflakes::DataSize for #ident #type_generics #where_clause {
 			fn data_size(&self) -> usize {
 				Self::static_data_size()
 			}

--- a/datasize_macro/src/lib.rs
+++ b/datasize_macro/src/lib.rs
@@ -1,4 +1,6 @@
-use impl_data_sizes::{impl_datasize, impl_static_data_size, retrieve_generics};
+use impl_data_sizes::{
+	impl_datasize, impl_static_data_size, retrieve_generics, retrieve_lifetimes,
+};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
@@ -10,15 +12,26 @@ pub fn derive_data_size(item: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(item as DeriveInput);
 	let ident = &input.ident;
 	let inner = impl_datasize(&input);
+
+	// Parsing generics and lifetimes
 	let generics = retrieve_generics(&input);
+	let lifetimes = retrieve_lifetimes(&input);
+	// Here we check if there is any lifetime AND generics
+	// if there is both, we need a comma to separate them
+	let generics_and_lifetimes = if generics.len() > 0 && lifetimes.len() > 0 {
+		quote!(<#(#lifetimes),*, #(#generics)*>)
+	} else {
+		quote!(<#(#lifetimes),* #(#generics)*>)
+	};
 
 	let output = quote! {
-		impl<#(#generics: DataSize),*> cornflakes::datasize::DataSize for #ident<#(#generics)*> {
+		impl<#(#generics: DataSize),*> cornflakes::datasize::DataSize for #ident #generics_and_lifetimes {
 			default fn data_size(&self) -> usize {
 				#inner
 			}
 		}
 	};
+	dbg!(&output.to_string());
 	output.into()
 }
 
@@ -27,20 +40,31 @@ pub fn derive_static_data_size(item: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(item as DeriveInput);
 	let ident = &input.ident;
 	let inner = impl_static_data_size(&input);
+
+	// Parsing generics and lifetimes
 	let generics = retrieve_generics(&input);
+	let lifetimes = retrieve_lifetimes(&input);
+	// Here we check if there is any lifetime AND generics
+	// if there is both, we need a comma to separate them
+	let generics_and_lifetimes = if generics.len() > 0 && lifetimes.len() > 0 {
+		quote!(<#(#lifetimes),*, #(#generics)*>)
+	} else {
+		quote!(<#(#lifetimes),* #(#generics)*>)
+	};
 
 	// TODO: Move the implementation for `DataSize` to the appropriate derive macro
 	let output = quote! {
-		impl<#(#generics: StaticDataSize),*> cornflakes::datasize::StaticDataSize for #ident<#(#generics)*> {
+		impl<#(#generics: StaticDataSize),*> cornflakes::datasize::StaticDataSize for #ident #generics_and_lifetimes {
 			fn static_data_size() -> usize {
 				#inner
 			}
 		}
-		impl<#(#generics: StaticDataSize + DataSize),*> cornflakes::datasize::DataSize for #ident<#(#generics)*> {
+		impl<#(#generics: StaticDataSize + DataSize),*> cornflakes::datasize::DataSize for #ident #generics_and_lifetimes {
 			fn data_size(&self) -> usize {
 				Self::static_data_size()
 			}
 		}
 	};
+	dbg!(&output.to_string());
 	output.into()
 }

--- a/src/datasize.rs
+++ b/src/datasize.rs
@@ -72,7 +72,7 @@ impl DataSize for &str {
 impl<T: DataSize> DataSize for Option<T> {
 	default fn data_size(&self) -> usize {
 		match &self {
-			Option::None => 0,
+			Option::None => 1,
 			Option::Some(v) => v.data_size(),
 		}
 	}

--- a/src/datasize.rs
+++ b/src/datasize.rs
@@ -2,23 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::{DataSize, StaticDataSize};
+
 pub mod derive {
 	pub use datasize_macro::{DataSize, StaticDataSize};
-}
-
-pub trait DataSize {
-	/// Returns the size of `self` in bytes when written with [`Writable`].
-	fn data_size(&self) -> usize;
-}
-
-pub trait StaticDataSize {
-	/// Returns the size of `Self` in bytes when written with [`Writable`].
-	///
-	/// If `Self` is an `enum`, then the size is the maximum size of the values
-	/// contained in the variants
-	fn static_data_size() -> usize
-	where
-		Self: Sized;
 }
 
 // Implementations for primitive types used in xrb
@@ -53,7 +40,7 @@ static_type_size!(f64);
 
 impl<T: DataSize> DataSize for Vec<T> {
 	fn data_size(&self) -> usize {
-		self.iter().map(|v| v.data_size()).fold(0, |acc, v| acc + v)
+		self.iter().map(|v| v.data_size()).sum()
 	}
 }
 

--- a/src/datasize.rs
+++ b/src/datasize.rs
@@ -41,10 +41,10 @@ static_type_size!(u8, 1);
 static_type_size!(i8, 1);
 static_type_size!(u16, 2);
 static_type_size!(i16, 2);
-static_type_size!(u32, 3);
-static_type_size!(i32, 3);
-static_type_size!(u64, 4);
-static_type_size!(i64, 4);
+static_type_size!(u32, 4);
+static_type_size!(i32, 4);
+static_type_size!(u64, 8);
+static_type_size!(i64, 8);
 
 impl<T> DataSize for Vec<T>
 where
@@ -78,5 +78,28 @@ where
 {
 	fn static_data_size() -> usize {
 	    T::static_data_size()
+	}
+}
+
+#[cfg(test)]
+mod test {
+    use super::DataSize;
+
+	#[test]
+	fn test_datasize_vec() {
+		let data = vec![i16::default(); 100];
+		assert_eq!(data.data_size(), 200);
+	}
+
+	#[test]
+	fn test_datasize_option_static() {
+		let data: Option<u64> = None;
+		assert_eq!(data.data_size(), 8);
+	}
+
+	#[test]
+	fn test_datasize_option_dynamic() {
+		let data: Option<Vec<i64>> = Some(vec![i64::default(); 10]);
+		assert_eq!(data.data_size(), 80);
 	}
 }

--- a/src/datasize.rs
+++ b/src/datasize.rs
@@ -72,9 +72,7 @@ impl<T: DataSize + StaticDataSize> DataSize for Option<T>
 		Self::static_data_size()
 	}
 }
-impl<T> StaticDataSize for Option<T>
-where
-	T: StaticDataSize,
+impl<T: StaticDataSize> StaticDataSize for Option<T>
 {
 	fn static_data_size() -> usize {
 	    T::static_data_size()

--- a/src/datasize.rs
+++ b/src/datasize.rs
@@ -16,7 +16,9 @@ pub trait StaticDataSize {
 	///
 	/// If `Self` is an `enum`, then the size is the maximum size of the values
 	/// contained in the variants
-	fn static_data_size() -> usize where Self: Sized;
+	fn static_data_size() -> usize
+	where
+		Self: Sized;
 }
 
 // Implementations for primitive types used in xrb
@@ -38,7 +40,6 @@ macro_rules! static_type_size {
 }
 
 static_type_size!(bool);
-static_type_size!(usize);
 static_type_size!(u8);
 static_type_size!(i8);
 static_type_size!(u16);
@@ -49,44 +50,39 @@ static_type_size!(u64);
 static_type_size!(i64);
 static_type_size!(f32);
 static_type_size!(f64);
-static_type_size!(char);
 
-impl<T: DataSize> DataSize for Vec<T>
-{
+impl<T: DataSize> DataSize for Vec<T> {
 	fn data_size(&self) -> usize {
-		self.iter()
-			.map(|v| v.data_size())
-			.fold(0, |acc, v| acc + v)
+		self.iter().map(|v| v.data_size()).fold(0, |acc, v| acc + v)
 	}
 }
 
 impl<T: DataSize> DataSize for &[T] {
 	fn data_size(&self) -> usize {
 		let size: &mut usize = &mut 0;
-	    for e in *self {
+		for e in *self {
 			*size += e.data_size();
-	    };
+		}
 		*size
 	}
 }
 impl<T: DataSize> DataSize for [T] {
 	fn data_size(&self) -> usize {
 		let size: &mut usize = &mut 0;
-	    for e in self {
+		for e in self {
 			*size += e.data_size();
-	    };
+		}
 		*size
 	}
 }
 
 impl DataSize for &str {
 	fn data_size(&self) -> usize {
-	    self.len()
+		self.len()
 	}
 }
 
-impl<T: DataSize> DataSize for Option<T>
-{
+impl<T: DataSize> DataSize for Option<T> {
 	default fn data_size(&self) -> usize {
 		match &self {
 			Option::None => 0,
@@ -94,22 +90,20 @@ impl<T: DataSize> DataSize for Option<T>
 		}
 	}
 }
-impl<T: DataSize + StaticDataSize> DataSize for Option<T>
-{
+impl<T: DataSize + StaticDataSize> DataSize for Option<T> {
 	fn data_size(&self) -> usize {
 		Self::static_data_size()
 	}
 }
-impl<T: StaticDataSize> StaticDataSize for Option<T>
-{
+impl<T: StaticDataSize> StaticDataSize for Option<T> {
 	fn static_data_size() -> usize {
-	    T::static_data_size()
+		T::static_data_size()
 	}
 }
 
 #[cfg(test)]
 mod test {
-    use super::DataSize;
+	use super::DataSize;
 
 	#[test]
 	fn test_datasize_vec() {

--- a/src/datasize.rs
+++ b/src/datasize.rs
@@ -4,10 +4,6 @@
 
 use crate::{DataSize, StaticDataSize};
 
-pub mod derive {
-	pub use datasize_macro::{DataSize, StaticDataSize};
-}
-
 // Implementations for primitive types used in xrb
 
 /// Simple macro for easely defining size for primitive types

--- a/src/datasize.rs
+++ b/src/datasize.rs
@@ -23,10 +23,10 @@ pub trait StaticDataSize {
 
 /// Simple macro for easely defining size for primitive types
 macro_rules! static_type_size {
-	($type:ty, $size:literal) => {
+	($type:ty) => {
 		impl StaticDataSize for $type {
 			fn static_data_size() -> usize {
-				$size
+				std::mem::size_of::<$type>()
 			}
 		}
 		impl DataSize for $type {
@@ -37,23 +37,51 @@ macro_rules! static_type_size {
 	};
 }
 
-static_type_size!(u8, 1);
-static_type_size!(i8, 1);
-static_type_size!(u16, 2);
-static_type_size!(i16, 2);
-static_type_size!(u32, 4);
-static_type_size!(i32, 4);
-static_type_size!(u64, 8);
-static_type_size!(i64, 8);
+static_type_size!(bool);
+static_type_size!(usize);
+static_type_size!(u8);
+static_type_size!(i8);
+static_type_size!(u16);
+static_type_size!(i16);
+static_type_size!(u32);
+static_type_size!(i32);
+static_type_size!(u64);
+static_type_size!(i64);
+static_type_size!(f32);
+static_type_size!(f64);
+static_type_size!(char);
 
-impl<T> DataSize for Vec<T>
-where
-	T: DataSize,
+impl<T: DataSize> DataSize for Vec<T>
 {
 	fn data_size(&self) -> usize {
 		self.iter()
 			.map(|v| v.data_size())
 			.fold(0, |acc, v| acc + v)
+	}
+}
+
+impl<T: DataSize> DataSize for &[T] {
+	fn data_size(&self) -> usize {
+		let size: &mut usize = &mut 0;
+	    for e in *self {
+			*size += e.data_size();
+	    };
+		*size
+	}
+}
+impl<T: DataSize> DataSize for [T] {
+	fn data_size(&self) -> usize {
+		let size: &mut usize = &mut 0;
+	    for e in self {
+			*size += e.data_size();
+	    };
+		*size
+	}
+}
+
+impl DataSize for &str {
+	fn data_size(&self) -> usize {
+	    self.len()
 	}
 }
 

--- a/src/datasize.rs
+++ b/src/datasize.rs
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+pub trait DataSize {
+	/// Returns the size of `self` in bytes when written with [`Writable`].
+	fn data_size(&self) -> usize;
+}
+
+pub trait StaticDataSize {
+	/// Returns the size of `Self` in bytes when written with [`Writable`].
+	///
+	/// If `Self` is an `enum`, then the size is the maximum size of the values
+	/// contained in the variants
+	fn static_data_size() -> usize where Self: Sized;
+}
+
+// Implementations for primitive types used in xrb
+
+/// Simple macro for easely defining size for primitive types
+macro_rules! static_type_size {
+	($type:ty, $size:literal) => {
+		impl StaticDataSize for $type {
+			fn static_data_size() -> usize {
+				$size
+			}
+		}
+		impl DataSize for $type {
+			fn data_size(&self) -> usize {
+				Self::static_data_size()
+			}
+		}
+	};
+}
+
+static_type_size!(u8, 1);
+static_type_size!(i8, 1);
+static_type_size!(u16, 2);
+static_type_size!(i16, 2);
+static_type_size!(u32, 3);
+static_type_size!(i32, 3);
+static_type_size!(u64, 4);
+static_type_size!(i64, 4);
+
+impl<T> DataSize for Vec<T>
+where
+	T: DataSize,
+{
+	fn data_size(&self) -> usize {
+		self.iter()
+			.map(|v| v.data_size())
+			.fold(0, |acc, v| acc + v)
+	}
+}
+
+impl<T: DataSize> DataSize for Option<T>
+{
+	default fn data_size(&self) -> usize {
+		match &self {
+			Option::None => 0,
+			Option::Some(v) => v.data_size(),
+		}
+	}
+}
+impl<T: DataSize + StaticDataSize> DataSize for Option<T>
+{
+	fn data_size(&self) -> usize {
+		Self::static_data_size()
+	}
+}
+impl<T> StaticDataSize for Option<T>
+where
+	T: StaticDataSize,
+{
+	fn static_data_size() -> usize {
+	    T::static_data_size()
+	}
+}

--- a/src/datasize.rs
+++ b/src/datasize.rs
@@ -88,6 +88,25 @@ impl<T: StaticDataSize> StaticDataSize for Option<T> {
 	}
 }
 
+// Size for references will be the same as the owned type.
+// We don't need to implement DataSize for references because
+// of auto-dereferencing at runtime.
+impl<T: StaticDataSize> StaticDataSize for &T {
+	fn static_data_size() -> usize {
+		<T>::static_data_size()
+	}
+}
+impl<T: StaticDataSize> StaticDataSize for &mut T {
+	fn static_data_size() -> usize {
+		<T>::static_data_size()
+	}
+}
+impl<T: StaticDataSize> StaticDataSize for Box<T> {
+	fn static_data_size() -> usize {
+		<T>::static_data_size()
+	}
+}
+
 #[cfg(test)]
 mod test {
 	use super::DataSize;

--- a/src/datasize.rs
+++ b/src/datasize.rs
@@ -2,6 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+pub mod derive {
+	pub use datasize_macro::{DataSize, StaticDataSize};
+}
+
 pub trait DataSize {
 	/// Returns the size of `self` in bytes when written with [`Writable`].
 	fn data_size(&self) -> usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Specialization is needed for implementing DataSize and StaticDataSize for Option<T>
+// We need specialization to implement DataSize for Wrapper types like Option<T>
+#![allow(incomplete_features)]
 #![feature(specialization)]
 
 // Deny the following clippy lints to enforce them:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// Specialization is needed for implementing DataSize and StaticDataSize for Option<T>
+#![feature(specialization)]
+
 // Deny the following clippy lints to enforce them:
 #![deny(clippy::complexity)]
 #![deny(clippy::correctness)]
@@ -21,13 +24,11 @@
 
 use std::error::Error;
 use bytes::{Buf, BufMut};
+use datasize::{DataSize, StaticDataSize};
 
 type Result<T = ()> = std::result::Result<T, Box<dyn Error>>;
 
-pub trait DataSize {
-	/// Returns the size of `self` in bytes when written with [`Writable`].
-	fn data_size(&self) -> usize;
-}
+pub mod datasize;
 
 /// Reads a type from bytes.
 pub trait Readable {
@@ -61,6 +62,7 @@ pub trait Writable {
 // cannot be used with the `dyn` keyword.
 fn _assert_object_safety(
 	_data_size: &dyn DataSize,
+	_static_data_size: &dyn StaticDataSize,
 	_readable: &dyn Readable,
 	_contextual_readable: &dyn ContextualReadable<Context=()>,
 	_writable: &dyn Writable,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,25 @@
 
 use std::error::Error;
 use bytes::{Buf, BufMut};
-use datasize::{DataSize, StaticDataSize};
 
 type Result<T = ()> = std::result::Result<T, Box<dyn Error>>;
 
 pub mod datasize;
+
+pub trait DataSize {
+	/// Returns the size of `self` in bytes when written with [`Writable`].
+	fn data_size(&self) -> usize;
+}
+
+pub trait StaticDataSize {
+	/// Returns the size of `Self` in bytes when written with [`Writable`].
+	///
+	/// If `Self` is an `enum`, then the size is the maximum size of the values
+	/// contained in the variants
+	fn static_data_size() -> usize
+	where
+		Self: Sized;
+}
 
 /// Reads a type from bytes.
 pub trait Readable {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,10 @@ use bytes::{Buf, BufMut};
 
 type Result<T = ()> = std::result::Result<T, Box<dyn Error>>;
 
+pub mod derive {
+	pub use datasize_macro::{DataSize, StaticDataSize};
+}
+
 pub mod datasize;
 
 pub trait DataSize {

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -6,8 +6,8 @@
 #![allow(incomplete_features)]
 #![feature(specialization)]
 
-use cornflakes::datasize::{
-	derive::{DataSize, StaticDataSize},
+use cornflakes::{
+	datasize::derive::{DataSize, StaticDataSize},
 	DataSize, StaticDataSize,
 };
 

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -116,7 +116,7 @@ fn test_sized_tuple() {
 #[test]
 fn test_dynamic_enum_unit() {
 	let data = TestDynamicEnum::Unit;
-	assert_eq!(data.data_size(), 0);
+	assert_eq!(data.data_size(), 1);
 }
 
 #[test]
@@ -175,7 +175,7 @@ fn test_enum_with_sized_generics_named() {
 #[test]
 fn test_enum_with_dynamic_generics_unit() {
 	let data = TestEnumGenerics::<Vec<u32>>::Unit;
-	assert_eq!(data.data_size(), 0);
+	assert_eq!(data.data_size(), 1);
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn test_struct_with_dynamic_generics() {
 		wrapper: Some(vec![u8::default(); 2]),
 		enum_value: TestEnumGenerics::Unit,
 	};
-	assert_eq!(data.data_size(), 3);
+	assert_eq!(data.data_size(), 4);
 }
 
 #[test]
@@ -222,5 +222,5 @@ fn test_tuple_with_sized_generics() {
 #[test]
 fn test_tuple_with_dynamic_generics() {
 	let data = TestTupleGenerics::<Vec<i8>>(Some(vec![i8::default(); 10]), TestEnumGenerics::Unit);
-	assert_eq!(data.data_size(), 10);
+	assert_eq!(data.data_size(), 11);
 }

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -41,10 +41,11 @@ enum TestDynamicEnum {
 /// Here the size cannot be known at compile time,
 /// So it can't implement `StaticDataSize`
 #[derive(DataSize)]
-struct TestDynamicStruct {
+struct TestDynamicStruct<'a> {
 	value: u32,
 	wrapper: Option<Vec<i32>>,
 	enum_value: Vec<TestSizedEnum>,
+	s: &'a [u32],
 }
 
 #[derive(DataSize)]
@@ -60,8 +61,8 @@ enum TestEnumGenerics<T> {
 }
 
 #[derive(DataSize, StaticDataSize)]
-struct TestStructGenerics<T> {
-	value: T,
+struct TestStructGenerics<'a, T> {
+	value: &'a T,
 	wrapper: Option<T>,
 	enum_value: TestEnumGenerics<T>,
 }
@@ -136,8 +137,9 @@ fn test_dynamic_struct() {
 		value: u32::default(),
 		wrapper: Some(Vec::from([i32::default(), i32::default()])),
 		enum_value: Vec::from([TestSizedEnum::Unit]),
+		s: &[u32::default()],
 	};
-	assert_eq!(data.data_size(), 17);
+	assert_eq!(data.data_size(), 21);
 }
 
 #[test]
@@ -191,7 +193,7 @@ fn test_enum_with_dynamic_generics_named() {
 #[test]
 fn test_struct_with_sized_generics() {
 	let data = TestStructGenerics::<u16> {
-		value: u16::default(),
+		value: &u16::default(),
 		wrapper: None,
 		enum_value: TestEnumGenerics::Unit,
 	};
@@ -201,7 +203,7 @@ fn test_struct_with_sized_generics() {
 #[test]
 fn test_struct_with_dynamic_generics() {
 	let data = TestStructGenerics::<Vec<u8>> {
-		value: vec![u8::default()],
+		value: &vec![u8::default()],
 		wrapper: Some(vec![u8::default(); 2]),
 		enum_value: TestEnumGenerics::Unit,
 	};

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -58,38 +58,19 @@ enum TestEnumGenerics<T> {
 	Unnamed(T),
 	Named { field1: T, field2: T },
 }
+
 #[derive(DataSize, StaticDataSize)]
 struct TestStructGenerics<T> {
 	value: T,
 	wrapper: Option<T>,
 	enum_value: TestEnumGenerics<T>,
 }
+
 #[derive(DataSize, StaticDataSize)]
 struct TestTupleGenerics<T>(Option<T>, TestEnumGenerics<T>);
 
-// TODO: Under here is what the derive should generate for types with generics
-//       that implements both DataSize and StaticDataSize.
-//       Note that we need specialization for now, and this is a Nightly only feature.
-//
-// impl<T: DataSize> DataSize for TestSizedEnumGenerics<T> {
-// 	default fn data_size(&self) -> usize {
-// 		match &self {
-// 			TestSizedEnumGenerics::Unit => 0,
-// 			TestSizedEnumGenerics::Unnamed(a) => a.data_size(),
-// 			TestSizedEnumGenerics::Named { field1, field2 } => field1.data_size() + field2.data_size(),
-// 		}
-// 	}
-// }
-// impl<T: DataSize + StaticDataSize> DataSize for TestSizedEnumGenerics<T> {
-// 	fn data_size(&self) -> usize {
-// 		T::static_data_size()
-// 	}
-// }
-// impl<T: StaticDataSize> StaticDataSize for TestSizedEnumGenerics<T> {
-// 	fn static_data_size() -> usize {
-// 		T::static_data_size()
-// 	}
-// }
+
+// Tests
 
 #[test]
 fn test_sized_enum_unit() {
@@ -214,7 +195,7 @@ fn test_struct_with_sized_generics() {
 		wrapper: None,
 		enum_value: TestEnumGenerics::Unit,
 	};
-	assert_eq!(data.data_size(), 6);
+	assert_eq!(data.data_size(), 8);
 }
 
 #[test]
@@ -222,7 +203,7 @@ fn test_struct_with_dynamic_generics() {
 	let data = TestStructGenerics::<Vec<u8>> {
 		value: vec![u8::default()],
 		wrapper: Some(vec![u8::default(); 2]),
-		enum_value: vec![TestEnumGenerics::Unit],
+		enum_value: TestEnumGenerics::Unit,
 	};
 	assert_eq!(data.data_size(), 3);
 }
@@ -230,11 +211,11 @@ fn test_struct_with_dynamic_generics() {
 #[test]
 fn test_tuple_with_sized_generics() {
 	let data = TestTupleGenerics::<i8>(None, TestEnumGenerics::Unit);
-	assert_eq!(data.data_size(), 2);
+	assert_eq!(data.data_size(), 3);
 }
 
 #[test]
 fn test_tuple_with_dynamic_generics() {
-	let data = TestTupleGenerics::<Vec<i8>>(Some(vec![i8::default; 10]), TestEnumGenerics::Unit);
+	let data = TestTupleGenerics::<Vec<i8>>(Some(vec![i8::default(); 10]), TestEnumGenerics::Unit);
 	assert_eq!(data.data_size(), 10);
 }

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -65,7 +65,7 @@ enum TestEnumGenerics<T> {
 }
 
 #[derive(DataSize, StaticDataSize)]
-struct TestStructGenerics<'a, T> {
+struct TestStructGenerics<'a, T: 'a> {
 	value: &'a T,
 	wrapper: Option<T>,
 	enum_value: TestEnumGenerics<Option<T>>,

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -70,7 +70,6 @@ struct TestStructGenerics<'a, T> {
 #[derive(DataSize, StaticDataSize)]
 struct TestTupleGenerics<T>(Option<T>, TestEnumGenerics<T>);
 
-
 // Tests
 
 #[test]

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -25,8 +25,8 @@ struct TestSizedStruct {
 }
 
 // TODO: Do we need this ?
-// #[derive(StaticDataSize)]
-// struct TestSizedTuple(u32, Option<i64>);
+#[derive(StaticDataSize)]
+struct TestSizedTuple(u32, Option<i64>);
 
 /// Here the size cannot be known at compile time,
 /// So it can't implement `StaticDataSize`
@@ -47,8 +47,8 @@ struct TestDynamicStruct {
 }
 
 // TODO: Do we need this ?
-// #[derive(DataSize)]
-// struct TestDynamicTuple(Vec<Option<u64>>, i64);
+#[derive(DataSize)]
+struct TestDynamicTuple(Vec<Option<u64>>, i64);
 
 #[test]
 fn test_sized_enum_unit() {
@@ -81,11 +81,11 @@ fn test_sized_struct() {
 	assert_eq!(data.data_size(), 17);
 }
 
-// #[test]
-// fn test_sized_tuple() {
-// 	let data = TestSizedTuple(u32::default(), None);
-// 	assert_eq!(data.data_size(), 12);
-// }
+#[test]
+fn test_sized_tuple() {
+	let data = TestSizedTuple(u32::default(), None);
+	assert_eq!(data.data_size(), 12);
+}
 
 #[test]
 fn test_dynamic_enum_unit() {
@@ -118,8 +118,8 @@ fn test_dynamic_struct() {
 	assert_eq!(data.data_size(), 17);
 }
 
-// #[test]
-// fn test_dynamic_tuple() {
-// 	let data = TestDynamicTuple(vec![None; 10], i64::default());
-// 	assert_eq!(data.data_size(), 88);
-// }
+#[test]
+fn test_dynamic_tuple() {
+	let data = TestDynamicTuple(vec![None; 10], i64::default());
+	assert_eq!(data.data_size(), 88);
+}

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 use cornflakes::datasize::{
 	derive::{DataSize, StaticDataSize},
 	DataSize, StaticDataSize,

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -7,7 +7,7 @@
 #![feature(specialization)]
 
 use cornflakes::{
-	datasize::derive::{DataSize, StaticDataSize},
+	derive::{DataSize, StaticDataSize},
 	DataSize, StaticDataSize,
 };
 

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![allow(unused)]
 #![allow(incomplete_features)]
 #![feature(specialization)]

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -64,7 +64,7 @@ enum TestEnumGenerics<T> {
 struct TestStructGenerics<'a, T> {
 	value: &'a T,
 	wrapper: Option<T>,
-	enum_value: TestEnumGenerics<T>,
+	enum_value: TestEnumGenerics<Option<T>>,
 }
 
 #[derive(DataSize, StaticDataSize)]

--- a/tests/datasize_derive_test.rs
+++ b/tests/datasize_derive_test.rs
@@ -2,6 +2,7 @@ use cornflakes::datasize::{
 	derive::{DataSize, StaticDataSize},
 	DataSize, StaticDataSize,
 };
+
 /// Here the size can be known at compile time
 ///
 /// Regardless of the variant chosen at runtime,
@@ -9,8 +10,8 @@ use cornflakes::datasize::{
 #[derive(StaticDataSize)]
 enum TestSizedEnum {
 	Unit,
-	Tuple(u16),
-	Struct { field1: u32, field2: i8 },
+	Unnamed(u16),
+	Named { field1: u32, field2: i8 },
 }
 
 /// Here the size can be known at compile time
@@ -21,13 +22,17 @@ struct TestSizedStruct {
 	enum_value: TestSizedEnum,
 }
 
+// TODO: Do we need this ?
+// #[derive(StaticDataSize)]
+// struct TestSizedTuple(u32, Option<i64>);
+
 /// Here the size cannot be known at compile time,
 /// So it can't implement `StaticDataSize`
 #[derive(DataSize)]
 enum TestDynamicEnum {
 	Unit,
-	Tuple(Vec<u8>),
-	Struct { field1: u32, field2: Vec<i16> },
+	Unnamed(Vec<u8>),
+	Named { field1: u32, field2: Vec<i16> },
 }
 
 /// Here the size cannot be known at compile time,
@@ -39,6 +44,10 @@ struct TestDynamicStruct {
 	enum_value: Vec<TestSizedEnum>,
 }
 
+// TODO: Do we need this ?
+// #[derive(DataSize)]
+// struct TestDynamicTuple(Vec<Option<u64>>, i64);
+
 #[test]
 fn test_sized_enum_unit() {
 	let data = TestSizedEnum::Unit;
@@ -46,14 +55,14 @@ fn test_sized_enum_unit() {
 }
 
 #[test]
-fn test_sized_enum_tuple() {
-	let data = TestSizedEnum::Tuple(u16::default());
+fn test_sized_enum_unnamed() {
+	let data = TestSizedEnum::Unnamed(u16::default());
 	assert_eq!(data.data_size(), 5);
 }
 
 #[test]
-fn test_sized_enum_struct() {
-	let data = TestSizedEnum::Struct {
+fn test_sized_enum_named() {
+	let data = TestSizedEnum::Named {
 		field1: u32::default(),
 		field2: i8::default(),
 	};
@@ -70,6 +79,12 @@ fn test_sized_struct() {
 	assert_eq!(data.data_size(), 17);
 }
 
+// #[test]
+// fn test_sized_tuple() {
+// 	let data = TestSizedTuple(u32::default(), None);
+// 	assert_eq!(data.data_size(), 12);
+// }
+
 #[test]
 fn test_dynamic_enum_unit() {
 	let data = TestDynamicEnum::Unit;
@@ -77,18 +92,18 @@ fn test_dynamic_enum_unit() {
 }
 
 #[test]
-fn test_dynamic_enum_tuple() {
-	let data = TestDynamicEnum::Tuple(Vec::from([u8::default(), u8::default()]));
+fn test_dynamic_enum_unnamed() {
+	let data = TestDynamicEnum::Unnamed(Vec::from([u8::default(), u8::default()]));
 	assert_eq!(data.data_size(), 2);
 }
 
 #[test]
-fn test_dynamic_enum_struct() {
-	let data = TestDynamicEnum::Struct {
+fn test_dynamic_enum_named() {
+	let data = TestDynamicEnum::Named {
 		field1: u32::default(),
-		field2: Vec::from([i16::default(), i16::default(), i16::default()]),
+		field2: vec![i16::default(); 10],
 	};
-	assert_eq!(data.data_size(), 10);
+	assert_eq!(data.data_size(), 24);
 }
 
 #[test]
@@ -100,3 +115,9 @@ fn test_dynamic_struct() {
 	};
 	assert_eq!(data.data_size(), 17);
 }
+
+// #[test]
+// fn test_dynamic_tuple() {
+// 	let data = TestDynamicTuple(vec![None; 10], i64::default());
+// 	assert_eq!(data.data_size(), 88);
+// }

--- a/tests/datasize_test.rs
+++ b/tests/datasize_test.rs
@@ -1,0 +1,102 @@
+use cornflakes::datasize::{
+	derive::{DataSize, StaticDataSize},
+	DataSize, StaticDataSize,
+};
+/// Here the size can be known at compile time
+///
+/// Regardless of the variant chosen at runtime,
+/// `data_size()` should always return the size of the largest variant
+#[derive(StaticDataSize)]
+enum TestSizedEnum {
+	Unit,
+	Tuple(u16),
+	Struct { field1: u32, field2: i8 },
+}
+
+/// Here the size can be known at compile time
+#[derive(StaticDataSize)]
+struct TestSizedStruct {
+	value: u32,
+	wrapper: Option<i64>,
+	enum_value: TestSizedEnum,
+}
+
+/// Here the size cannot be known at compile time,
+/// So it can't implement `StaticDataSize`
+#[derive(DataSize)]
+enum TestDynamicEnum {
+	Unit,
+	Tuple(Vec<u8>),
+	Struct { field1: u32, field2: Vec<i16> },
+}
+
+/// Here the size cannot be known at compile time,
+/// So it can't implement `StaticDataSize`
+#[derive(DataSize)]
+struct TestDynamicStruct {
+	value: u32,
+	wrapper: Option<Vec<i32>>,
+	enum_value: Vec<TestSizedEnum>,
+}
+
+#[test]
+fn test_sized_enum_unit() {
+	let data = TestSizedEnum::Unit;
+	assert_eq!(data.data_size(), 5);
+}
+
+#[test]
+fn test_sized_enum_tuple() {
+	let data = TestSizedEnum::Tuple(u16::default());
+	assert_eq!(data.data_size(), 5);
+}
+
+#[test]
+fn test_sized_enum_struct() {
+	let data = TestSizedEnum::Struct {
+		field1: u32::default(),
+		field2: i8::default(),
+	};
+	assert_eq!(data.data_size(), 5);
+}
+
+#[test]
+fn test_sized_struct() {
+	let data = TestSizedStruct {
+		value: u32::default(),
+		wrapper: None,
+		enum_value: TestSizedEnum::Unit,
+	};
+	assert_eq!(data.data_size(), 17);
+}
+
+#[test]
+fn test_dynamic_enum_unit() {
+	let data = TestDynamicEnum::Unit;
+	assert_eq!(data.data_size(), 0);
+}
+
+#[test]
+fn test_dynamic_enum_tuple() {
+	let data = TestDynamicEnum::Tuple(Vec::from([u8::default(), u8::default()]));
+	assert_eq!(data.data_size(), 2);
+}
+
+#[test]
+fn test_dynamic_enum_struct() {
+	let data = TestDynamicEnum::Struct {
+		field1: u32::default(),
+		field2: Vec::from([i16::default(), i16::default(), i16::default()]),
+	};
+	assert_eq!(data.data_size(), 10);
+}
+
+#[test]
+fn test_dynamic_struct() {
+	let data = TestDynamicStruct {
+		value: u32::default(),
+		wrapper: Some(Vec::from([i32::default(), i32::default()])),
+		enum_value: Vec::from([TestSizedEnum::Unit]),
+	};
+	assert_eq!(data.data_size(), 17);
+}


### PR DESCRIPTION
It is now possible to implement `StaticDataSize` and `DataSize` traits with derive macro !
```rust
// Both enums and structs with named or unnamed fields are supported

// Deriving for StaticDataSize will also implement DataSize
// You don't need to add a derive for DataSize (It will not compile anyways)
#[derive(StaticDataSize)] // The size is known at compile time
enum TestSizedEnum {
	Unit,
	Unnamed(u16),
	Named { field1: u32, field2: i8 },
}
#[derive(DataSize)] // The size will change
struct TestDynamicTuple(Vec<Option<u64>>, i64);

// Even Generics works !!!
#[derive(DataSize, StaticDataSize)] // Here T could be statically sized or not, so we can derive both traits
struct TestStructGenerics<'a, T> {
	value: &'a T,
	wrapper: Option<T>,
	enum_value: TestEnumGenerics<Option<T>>,
}
```

The only thing left to do is the documentation :)