### PR TITLE
Fixed `static_data_size()` call on types for enums

### DIFF
--- a/datasize_macro/src/impl_data_sizes.rs
+++ b/datasize_macro/src/impl_data_sizes.rs
@@ -110,7 +110,7 @@ fn impl_static_datasize_enum(data_enum: &DataEnum) -> TokenStream2 {
 			// Retrieve types for all fields
 			let types: Vec<&Type> = variant.fields.iter().map(|f| &f.ty).collect();
 			quote! {
-				0usize #( + #types::static_data_size())*
+				0usize #( + <#types>::static_data_size())*
 			}
 		})
 		// Use the maximum size among all variants


### PR DESCRIPTION
I missed this, and it's important.